### PR TITLE
Added install target to rnnoise ladspa module

### DIFF
--- a/c/ladspa/Makefile
+++ b/c/ladspa/Makefile
@@ -1,3 +1,8 @@
+PREFIX = /usr/local
+
 default: 
 	$(CC) -Wall -Werror -O2 -c -fPIC ../ringbuf.c ../rnnoise/*.c module.c 
 	$(CC) -o rnnoise_ladspa.so *.o -shared -Wl,--version-script=export.txt -lm
+
+install: default
+	install -Dm755 rnnoise_ladspa.so $(DESTDIR)$(PREFIX)/lib/ladspa/rnnoise_ladspa.so


### PR DESCRIPTION
This PR adds a install target to the rnnoise ladspa plugin Makefile so you can install the plugin without having to install the entire application