### PR TITLE
feat(ci): add flawfinder action

### DIFF
--- a/.github/workflows/flawfinder.yml
+++ b/.github/workflows/flawfinder.yml
@@ -1,0 +1,39 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: flawfinder
+
+on:
+  push:
+    branches: [ master, main ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master, main ]
+  schedule:
+    - cron: '17 0 * * 1'
+
+jobs:
+  flawfinder:
+    name: Flawfinder
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: flawfinder_scan
+        uses: david-a-wheeler/flawfinder@8e4a779ad59dbfaee5da586aa9210853b701959c
+        with:
+          arguments: '--sarif ./c/'
+          output: 'flawfinder_results.sarif'
+
+      - name: Upload analysis results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        with:
+          sarif_file: ${{github.workspace}}/flawfinder_results.sarif
+          category: flawfinder

--- a/.github/workflows/flawfinder.yml
+++ b/.github/workflows/flawfinder.yml
@@ -36,4 +36,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2
         with:
           sarif_file: ${{github.workspace}}/flawfinder_results.sarif
-          category: flawfinder


### PR DESCRIPTION
Same as with the other PR from earlier: take your time, this won't run away.

....

Here is another idea for regularly scanning the C code for probable issues: [flawfinder](https://dwheeler.com/flawfinder/) 

> [...] flawfinder, a simple program that examines C/C++ source code and reports possible security weaknesses (“flaws”) sorted by risk level. It’s very useful for quickly finding and removing at least some potential security problems before a program is widely released to the public.

Scanning results with be shown in the pullrequest checks section:

![grafik](https://user-images.githubusercontent.com/1178490/169394603-e524464d-6b1d-454b-9b65-bd909b398da2.png)

as well as the security tab of the project:

![grafik](https://user-images.githubusercontent.com/1178490/169394764-1c7f525e-bdfd-402d-84f9-acd6c26eef8f.png)

So they will provide a good overview on possible improvements.

Though not all the findings have to be valid issues. Some may be conscious decisions - for example those complaints, that something can be accesses from outside of the C code (I guess at least some of that is needed to access those with the Go part of NoiseTorch?)


