### PR TITLE
Enable CodeQL for static code analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -50,8 +50,7 @@ jobs:
         # Prefix the list here with "+" to use these queries and those in the config file.
         
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-        # queries: security-extended,security-and-quality
-
+        queries: security-extended
         
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)

--- a/README.md
+++ b/README.md
@@ -7,4 +7,6 @@
 
 At least one of my sytems has probably been compromised, dont use the source either. One could hide things in a large diff.
 
-This project is dead, i've failed you. Sorry.
+If the community can help review ALL of the code, maybe we can trust the codw again and work from there.
+
+To help go here: https://github.com/lawl/NoiseTorch/issues/254#issuecomment-1130763165


### PR DESCRIPTION
:wave: hello! i got a notification that this app may be compromised, so i thought i'd enable CodeQL on this repository. 

CodeQL is github's static code analysis tool that can help identify vulnerabilities in your source code, and it's completely free for free and open source repositories such as yours. it can aid you in your code review process by attempting to identify intentionally placed vulnerabilities or other malicious patterns (e.g. backdoors). however, an advanced attacker may be able to evade detection even with static code analysis enabled, so if no results are found, don't take that necessarily to mean that your code isn't vulnerable. 

the workflow file that was created is an auto-generated file with the only change being made is i changed the default query set to be `security-extended`. all this means is that it tells CodeQL to include queries that may have a higher false positive rate, so if you think you're getting false positives, you can delete or comment out line 53. (note: it says `cpp` in the languages, but this includes `c`). 

the only thing you may need to do is ensure that CodeQL is able to build your code correctly so it can scan all of files. CodeQL monitors the build process to make sure it doesn't miss anything, so if there are problems, you may need to use custom build commands rather than using its autobuilder. as i'm not familiar with the project, i'm not really able to make that call as to what may need to be modified. 

of course, if you do not feel like using CodeQL, you won't hurt my feelings :smile: 

if you have any questions, feel free to reach out. 