### PR TITLE
Minor Cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 bin/
 licenses.go
+*.sublime-workspace
+*.sublime-project

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
- <img src="https://raw.githubusercontent.com/lawl/NoiseTorch/master/assets/icon/noisetorch.png" width="100" height="100">
+ <img src="https://raw.githubusercontent.com/noisetorch/NoiseTorch/master/assets/icon/noisetorch.png" width="100" height="100">
 
 # NoiseTorch
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
-[![Last Release](https://img.shields.io/github/v/release/lawl/NoiseTorch?label=latest&style=flat-square)](https://github.com/lawl/NoiseTorch/releases)
+[![Last Release](https://img.shields.io/github/v/release/noisetorch/NoiseTorch?label=latest&style=flat-square)](https://github.com/noisetorch/NoiseTorch/releases)
 
 ## Probable insecurity / remove NoiseTorch
 

--- a/ui.go
+++ b/ui.go
@@ -75,7 +75,7 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 		}
 		w.Row(10).Dynamic(1)
 		if w.MenuItem(label.T("Source code")) {
-			exec.Command("xdg-open", "https://github.com/lawl/NoiseTorch").Run()
+			exec.Command("xdg-open", "https://github.com/noisetorch/NoiseTorch").Run()
 		}
 		if w.MenuItem(label.T("Version")) {
 			ctx.views.Push(versionView)


### PR DESCRIPTION
Just some minor cleanups that I noticed while looking at some other code in the UI.
* Add Sublime Text to .gitignore: if others use Sublime as well it may be worth committing the .sublime-project file to the repo, the Sublime gitignore recommends it in that case but I don't feel too strongly either way.
* Fix URLs in README to point to the noisetorch org.
* Fix URL in About->Source Code to point to the noisetorch org.