### PR TITLE
fix: Make input selection aware of if "Show Monitor Sources" is checked

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -319,7 +319,7 @@ func inputSelection(ctx *ntcontext) (device, bool) {
 	}
 
 	for _, in := range ctx.inputList {
-		if in.checked && !(in.isMonitor && !ctx.config.DisplayMonitorSources) {
+		if in.checked && (!in.isMonitor || ctx.config.DisplayMonitorSources) {
 			return in, true
 		}
 	}

--- a/ui.go
+++ b/ui.go
@@ -319,7 +319,7 @@ func inputSelection(ctx *ntcontext) (device, bool) {
 	}
 
 	for _, in := range ctx.inputList {
-		if in.checked {
+		if in.checked && !(in.isMonitor && !ctx.config.DisplayMonitorSources) {
 			return in, true
 		}
 	}

--- a/ui.go
+++ b/ui.go
@@ -82,7 +82,7 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 	w.Row(15).Dynamic(1)
 
 	if ctx.noiseSupressorState == loaded {
-		if (ctx.virtualDeviceInUse) {
+		if ctx.virtualDeviceInUse {
 			w.LabelColored("NoiseTorch active", "RC", green)
 		} else {
 			w.LabelColored("NoiseTorch unconfigured", "RC", lightBlue)


### PR DESCRIPTION
Kind of a small corner case fix for a problem I noticed while working on a different ui problem. When Display Monitor Sources is unchecked and no mic is plugged in, if Filter Microphone is checked, Load NoiseTorch will be available with the monitor source as the "checked" element, even though it is hidden. This small modification to the check in inputSelection() fixes this bug.

Also removes a set of unnecessary parenthesis in an if.