### PR TITLE
fix: When filter is selected but no device is selected show unconfigured

### DIFF
--- a/ui.go
+++ b/ui.go
@@ -88,7 +88,13 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 			w.LabelColored("NoiseTorch unconfigured", "RC", lightBlue)
 		}
 	} else if ctx.noiseSupressorState == unloaded {
-		w.LabelColored("NoiseTorch inactive", "RC", red)
+		_, inpOk := inputSelection(ctx)
+		_, outOk := outputSelection(ctx)
+		if validConfiguration(ctx, inpOk, outOk) {
+			w.LabelColored("NoiseTorch inactive", "RC", red)
+		} else {
+			w.LabelColored("NoiseTorch unconfigured", "RC", lightBlue)
+		}
 	} else if ctx.noiseSupressorState == inconsistent {
 		w.LabelColored("Inconsistent state, please unload first.", "RC", orange)
 	}
@@ -237,10 +243,7 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 
 	inp, inpOk := inputSelection(ctx)
 	out, outOk := outputSelection(ctx)
-	if (!ctx.config.FilterInput || (ctx.config.FilterInput && inpOk)) &&
-		(!ctx.config.FilterOutput || (ctx.config.FilterOutput && outOk)) &&
-		(ctx.config.FilterInput || ctx.config.FilterOutput) &&
-		ctx.noiseSupressorState != inconsistent {
+	if validConfiguration(ctx, inpOk, outOk) {
 		if w.ButtonText(txt) {
 			ctx.reloadRequired = false
 
@@ -337,6 +340,13 @@ func outputSelection(ctx *ntcontext) (device, bool) {
 		}
 	}
 	return device{}, false
+}
+
+func validConfiguration(ctx *ntcontext, inpOk bool, outOk bool) (bool) {
+	return (!ctx.config.FilterInput || (ctx.config.FilterInput && inpOk)) &&
+		(!ctx.config.FilterOutput || (ctx.config.FilterOutput && outOk)) &&
+		(ctx.config.FilterInput || ctx.config.FilterOutput) &&
+		ctx.noiseSupressorState != inconsistent
 }
 
 func loadingView(ctx *ntcontext, w *nucular.Window) {


### PR DESCRIPTION
As suggested in https://github.com/noisetorch/NoiseTorch/pull/286. When filtering is selected but a device to filter isn't, show unconfigured rather than inactive. I more or less borrowed the logic for determining if the Load button should or shouldn't be shown, made it into a helper function, then made it be used in both cases.

I was somewhat on the fence about this but have come around to liking it.