### PR TITLE
fix(update): strip 'v' from version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ release: rnnoise
 
 	mkdir -p tmp/.local/bin/
 	go generate
-	CGO_ENABLED=0 GOOS=linux go build -trimpath -tags release -a -ldflags '-s -w -extldflags "-static" -X main.version=${VERSION} -X main.distribution=official' .
+	CGO_ENABLED=0 GOOS=linux go build -trimpath -tags release -a -ldflags '-s -w -extldflags "-static" -X main.version=${VERSION} -X main.distribution=official -X main.updateURL=${UPDATE_URL} -X main.publicKeyString=${UPDATE_PUBKEY}' .
 	mv noisetorch tmp/.local/bin/
 	cd tmp/; \
 	tar cvzf ../bin/NoiseTorch_x64_${VERSION}.tgz .

--- a/cli.go
+++ b/cli.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/blang/semver/v4"
 	"github.com/noisetorch/pulseaudio"
@@ -41,8 +42,8 @@ func doCLI(opt CLIOpts, config *config, librnnoise string) {
 	if opt.checkUpdate {
 		latestRelease, err := getLatestRelease()
 		if err == nil {
-			latestVersion, _ := semver.Make(latestRelease[1:])
-			currentVersion, _ := semver.Make(version[1:])
+			latestVersion, _ := semver.Make(strings.TrimLeft(latestRelease, "v"))
+			currentVersion, _ := semver.Make(strings.TrimLeft(version, "v"))
 			if currentVersion.Compare(latestVersion) == -1 {
 				fmt.Println("New version available: " + latestRelease)
 			} else {

--- a/cli.go
+++ b/cli.go
@@ -41,8 +41,8 @@ func doCLI(opt CLIOpts, config *config, librnnoise string) {
 	if opt.checkUpdate {
 		latestRelease, err := getLatestRelease()
 		if err == nil {
-			latestVersion, _ := semver.Make(latestRelease)
-			currentVersion, _ := semver.Make(version)
+			latestVersion, _ := semver.Make(latestRelease[1:])
+			currentVersion, _ := semver.Make(version[1:])
 			if currentVersion.Compare(latestVersion) == -1 {
 				fmt.Println("New version available: " + latestRelease)
 			} else {

--- a/update.go
+++ b/update.go
@@ -10,6 +10,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -75,8 +76,8 @@ type updateui struct {
 }
 
 var latestRelease, releaseError = getLatestRelease()
-var latestVersion, _ = semver.Make(latestRelease[1:])
-var currentVersion, _ = semver.Make(version[1:])
+var latestVersion, _ = semver.Make(strings.TrimLeft(latestRelease, "v"))
+var currentVersion, _ = semver.Make(strings.TrimLeft(version, "v"))
 
 func updateable() bool {
 	return updateURL != "" && publicKeyString != "" && releaseError == nil

--- a/update.go
+++ b/update.go
@@ -75,8 +75,8 @@ type updateui struct {
 }
 
 var latestRelease, releaseError = getLatestRelease()
-var latestVersion, _ = semver.Make(latestRelease)
-var currentVersion, _ = semver.Make(version)
+var latestVersion, _ = semver.Make(latestRelease[1:])
+var currentVersion, _ = semver.Make(version[1:])
 
 func updateable() bool {
 	return updateURL != "" && publicKeyString != "" && releaseError == nil


### PR DESCRIPTION
for comparing the version strings with semver (and only there), we need to strip the 'v' prefix from the version strings.