### PR TITLE
Remove references to NoiseTorch

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -30,7 +30,7 @@ If applicable, add the link to a pastebin with the output of `noisetorch -log` a
  - Distribution [e.g. Ubuntu 22.04, Arch]: 
  - DE [e.g. Plasma 5.24.5, GNOME 42.0]: 
  - Pulseaudio/Pipewire Version: 
- - NoiseTorch Version [e.g. v0.12.0]:
+ - NoiseTorch-ng Version [e.g. v0.12.0]:
 
 **Additional context**
 Add any other context about the problem here.

--- a/LICENSE
+++ b/LICENSE
@@ -5,10 +5,13 @@ This software is distributed under the GNU General Public License Version 3 ("GP
 
 In accordance with Section 7, subsection `c` of the GPLv3 the following additional term(s) apply:
 
-  * Conveying modified versions of this program ("NoiseTorch") must be marked as modified in a reasonable way.
-    Modified versions may not be conveyed to others under same name as the original program.
+  * Conveying modified versions of the program "NoiseTorch" must be marked as modified in a reasonable way.
+    Modified versions may not be conveyed to others under the name "NoiseTorch".
     Package names, source code, user interfaces and other visible appearances of the program name should make it obvious for users
     and potential users that the modified version differs from the original version of NoiseTorch it is based upon.
+
+  * The above term does not apply to this program's name ("NoiseTorch-ng") as it is a different name.
+    You may convey modified versions of this program under the name "NoiseTorch-ng".
 
 
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,5 @@
 NoiseTorch (c) 2020-2021 lawl (github.com/lawl)
+NoiseTorch-ng (c) 2022 NoiseTorch Community (https://github.com/noisetorch)
 
 This software is distributed under the GNU General Public License Version 3 ("GPLv3").
 

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+NAME_SUFFIX=
 UPDATE_URL=https://github.com/noisetorch/NoiseTorch/releases/download/
 
 UPDATE_PUBKEY=Md2rdsS+b6W0trgcqa5lAWP978Zj0sFmubJ252OPKwc=
@@ -6,7 +7,7 @@ VERSION := $(shell git describe --tags)
 dev: rnnoise
 	mkdir -p bin/
 	go generate
-	go build -ldflags '-X main.version=${VERSION}' -o bin/noisetorch
+	go build -ldflags '-X main.nameSuffix=${NAME_SUFFIX}_(dev) -X main.version=${VERSION}' -o bin/noisetorch
 release: rnnoise
 	mkdir -p bin/
 	mkdir -p tmp/
@@ -19,7 +20,7 @@ release: rnnoise
 
 	mkdir -p tmp/.local/bin/
 	go generate
-	CGO_ENABLED=0 GOOS=linux go build -trimpath -tags release -a -ldflags '-s -w -extldflags "-static" -X main.version=${VERSION} -X main.distribution=official -X main.updateURL=${UPDATE_URL} -X main.publicKeyString=${UPDATE_PUBKEY}' .
+	CGO_ENABLED=0 GOOS=linux go build -trimpath -tags release -a -ldflags '-s -w -extldflags "-static" -X main.nameSuffix=${NAME_SUFFIX} -X main.version=${VERSION} -X main.distribution=official -X main.updateURL=${UPDATE_URL} -X main.publicKeyString=${UPDATE_PUBKEY}' .
 	mv noisetorch tmp/.local/bin/
 	cd tmp/; \
 	tar cvzf ../bin/NoiseTorch_x64_${VERSION}.tgz .

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 NAME_SUFFIX=
 UPDATE_URL=https://github.com/noisetorch/NoiseTorch/releases/download/
+WEBSITE_URL=https://github.com/noisetorch/NoiseTorch
 
 UPDATE_PUBKEY=Md2rdsS+b6W0trgcqa5lAWP978Zj0sFmubJ252OPKwc=
 VERSION := $(shell git describe --tags)
@@ -7,7 +8,7 @@ VERSION := $(shell git describe --tags)
 dev: rnnoise
 	mkdir -p bin/
 	go generate
-	go build -ldflags '-X main.nameSuffix=${NAME_SUFFIX}_(dev) -X main.version=${VERSION}' -o bin/noisetorch
+	go build -ldflags '-X main.nameSuffix=${NAME_SUFFIX}_(dev) -X main.version=${VERSION} -X main.websiteURL=${WEBSITE_URL}' -o bin/noisetorch
 release: rnnoise
 	mkdir -p bin/
 	mkdir -p tmp/
@@ -20,7 +21,7 @@ release: rnnoise
 
 	mkdir -p tmp/.local/bin/
 	go generate
-	CGO_ENABLED=0 GOOS=linux go build -trimpath -tags release -a -ldflags '-s -w -extldflags "-static" -X main.nameSuffix=${NAME_SUFFIX} -X main.version=${VERSION} -X main.distribution=official -X main.updateURL=${UPDATE_URL} -X main.publicKeyString=${UPDATE_PUBKEY}' .
+	CGO_ENABLED=0 GOOS=linux go build -trimpath -tags release -a -ldflags '-s -w -extldflags "-static" -X main.nameSuffix=${NAME_SUFFIX} -X main.version=${VERSION} -X main.distribution=official -X main.updateURL=${UPDATE_URL} -X main.publicKeyString=${UPDATE_PUBKEY} -X main.websiteURL=${WEBSITE_URL}' .
 	mv noisetorch tmp/.local/bin/
 	cd tmp/; \
 	tar cvzf ../bin/NoiseTorch_x64_${VERSION}.tgz .

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center"> NoiseTorch</h1>
+<h1 align="center"> NoiseTorch-ng</h1>
 <h3 align="center"> Noise Supression Application for PulseAudio or Pipewire</h3>
 <p align="center"><img src="https://raw.githubusercontent.com/noisetorch/NoiseTorch/master/assets/icon/noisetorch.png" width="100" height="100"></p> 
 
@@ -17,7 +17,7 @@
 [stars-shield]: https://img.shields.io/github/stars/noisetorch/NoiseTorch?maxAge=2592000
 [stars-url]: https://github.com/noisetorch/NoiseTorch/stargazers/
 
-NoiseTorch is an easy to use open source application for Linux with PulseAudio or PipeWire. It creates a virtual microphone that suppresses noise, in any application. Use whichever conferencing or VOIP application you like and simply select the NoiseTorch Virtual Microphone as input to torch the sound of your mechanical keyboard, computer fans, trains and the likes.
+NoiseTorch-ng is an easy to use open source application for Linux with PulseAudio or PipeWire. It creates a virtual microphone that suppresses noise, in any application. Use whichever conferencing or VOIP application you like and simply select the filtered Virtual Microphone as input to torch the sound of your mechanical keyboard, computer fans, trains and the likes.
 
 Don't forget to leave a star ⭐ if this sounds useful to you! 
 
@@ -39,7 +39,7 @@ Due to a suspected security breach of the update server and code repository, the
 
 ![](https://i.imgur.com/T2wH0bl.png)
 
-Then simply select NoiseTorch as your microphone in any application. OBS, Mumble, Discord, anywhere.
+Then simply select "Filtered" as your microphone in any application. OBS, Mumble, Discord, anywhere.
 
 ![](https://i.imgur.com/nimi7Ne.png)
 
@@ -72,7 +72,7 @@ Give it the required permissions with `setcap`:
 
     sudo setcap 'CAP_SYS_RESOURCE=+ep' ~/.local/bin/noisetorch
 
-If noisetorch doesn't start after installation, you may also have to make sure that `~/.local/bin` is in your PATH. On most distributions e.g. Ubuntu, this should be the case by default. If it's not, make sure to append
+If NoiseTorch-ng doesn't start after installation, you may also have to make sure that `~/.local/bin` is in your PATH. On most distributions e.g. Ubuntu, this should be the case by default. If it's not, make sure to append
 
 ```
 if [ -d "$HOME/.local/bin" ] ; then
@@ -94,21 +94,21 @@ Please see the [Troubleshooting](https://github.com/noisetorch/NoiseTorch/wiki/T
 
 ## Usage
 
-Select the microphone you want to denoise, and click "Load NoiseTorch", NoiseTorch will create a virtual microphone called "NoiseTorch Microphone" that you can select in any application. Output filtering works the same way, simply output the applications you want to filter to "NoiseTorch Headphones".
+Select the microphone you want to denoise, and click "Load", NoiseTorch-ng will create a virtual microphone called "Filtered Microphone" that you can select in any application. Output filtering works the same way, simply output the applications you want to filter to "Filtered Headphones".
 
-When you're done using it, simply click "Unload NoiseTorch" to remove it again, until you need it next time.
+When you're done using it, simply click "Unload" to remove it again, until you need it next time.
 
-The slider "Voice Activation Threshold" under settings, allows you to choose how strict NoiseTorch should be in only allowing your microphone to send sounds when it detects voice.. Generally you want this up as high as possible. With a decent microphone, you can turn this to the maximum of 95%. If you cut out during talking, slowly lower this strictness until you find a value that works for you.
+The slider "Voice Activation Threshold" under settings, allows you to choose how strict NoiseTorch-ng should be in only allowing your microphone to send sounds when it detects voice.. Generally you want this up as high as possible. With a decent microphone, you can turn this to the maximum of 95%. If you cut out during talking, slowly lower this strictness until you find a value that works for you.
 
-If you set this to 0%, NoiseTorch will still dampen noise, but not deactivate your microphone if it doesn't detect voice.
+If you set this to 0%, NoiseTorch-ng will still dampen noise, but not deactivate your microphone if it doesn't detect voice.
 
-Please keep in mind that you will need to reload NoiseTorch for these changes to apply.
+Please keep in mind that you will need to reload NoiseTorch-ng for these changes to apply.
 
-Once NoiseTorch has been loaded, feel free to close the window, the virtual microphone will continue working until you explicitly unload it. The NoiseTorch process is not required anymore once it has been loaded.
+Once NoiseTorch-ng has been loaded, feel free to close the window, the virtual microphone will continue working until you explicitly unload it. The NoiseTorch-ng process is not required anymore once it has been loaded.
 
 ## Latency
 
-NoiseTorch may introduce a small amount of latency for microphone filtering. The amount of inherent latency introduced by noise supression is 10ms, this is very low and should not be a problem. Additionally PulseAudio currently introduces a variable amount of latency that depends on your system. Lowering this latency [requires a change in PulseAudio](https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/120).
+NoiseTorch-ng may introduce a small amount of latency for microphone filtering. The amount of inherent latency introduced by noise supression is 10ms, this is very low and should not be a problem. Additionally PulseAudio currently introduces a variable amount of latency that depends on your system. Lowering this latency [requires a change in PulseAudio](https://gitlab.freedesktop.org/pulseaudio/pulseaudio/-/issues/120).
 
 Output filtering currently introduces something on the order of ~100ms with pulseaudio. This should still be fine for regular conferences, VOIPing and gaming. Maybe not for competitive gaming teams.
 

--- a/c/ladspa/module.c
+++ b/c/ladspa/module.c
@@ -164,9 +164,9 @@ ON_LOAD_ROUTINE {
   if (g_psDescriptor != NULL) {
 
     g_psDescriptor->UniqueID = 16682994;
-    g_psDescriptor->Label = strdup("changemelater");
+    g_psDescriptor->Label = strdup("nt-filter");
     g_psDescriptor->Properties = LADSPA_PROPERTY_HARD_RT_CAPABLE;
-    g_psDescriptor->Name = strdup("nt-org rnnoise ladspa module");
+    g_psDescriptor->Name = strdup("nt-filter rnnoise ladspa module");
     g_psDescriptor->Maker = strdup("nt-org");
     g_psDescriptor->Copyright = strdup("GPL3+");
     g_psDescriptor->PortCount = 3;

--- a/c/ladspa/module.c
+++ b/c/ladspa/module.c
@@ -164,10 +164,10 @@ ON_LOAD_ROUTINE {
   if (g_psDescriptor != NULL) {
 
     g_psDescriptor->UniqueID = 16682994;
-    g_psDescriptor->Label = strdup("noisetorch");
+    g_psDescriptor->Label = strdup("changemelater");
     g_psDescriptor->Properties = LADSPA_PROPERTY_HARD_RT_CAPABLE;
-    g_psDescriptor->Name = strdup("NoiseTorch rnnoise ladspa module");
-    g_psDescriptor->Maker = strdup("lawl");
+    g_psDescriptor->Name = strdup("nt-org rnnoise ladspa module");
+    g_psDescriptor->Maker = strdup("nt-org");
     g_psDescriptor->Copyright = strdup("GPL3+");
     g_psDescriptor->PortCount = 3;
     piPortDescriptors =

--- a/capability.go
+++ b/capability.go
@@ -1,3 +1,6 @@
+// This file is part of the program "NoiseTorch-ng".
+// Please see the LICENSE file for copyright information.
+
 package main
 
 import (

--- a/cli.go
+++ b/cli.go
@@ -1,3 +1,6 @@
+// This file is part of the program "NoiseTorch-ng".
+// Please see the LICENSE file for copyright information.
+
 package main
 
 import (

--- a/config.go
+++ b/config.go
@@ -1,3 +1,6 @@
+// This file is part of the program "NoiseTorch-ng".
+// Please see the LICENSE file for copyright information.
+
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -38,7 +38,7 @@ type device struct {
 	rate           uint32
 }
 
-var appName = "NoiseTorch"
+var appName = "NoiseTorch-ng"
 
 var nameSuffix = ""         // will be changed by build
 var version = "unknown"     // ditto

--- a/main.go
+++ b/main.go
@@ -38,14 +38,20 @@ type device struct {
 	rate           uint32
 }
 
-const appName = "NoiseTorch"
+var appName = "NoiseTorch"
 
-var version = "unknown"     // will be changed by build
+var nameSuffix = ""         // will be changed by build
+var version = "unknown"     // ditto
 var distribution = "custom" // ditto
 var updateURL = ""          // ditto
 var publicKeyString = ""    // ditto
 
+
 func main() {
+	if (nameSuffix != "") {
+		appName += strings.Replace(nameSuffix, "_", " ", -1)
+	}
+
 	opt := parseCLIOpts()
 
 	if opt.doLog {

--- a/main.go
+++ b/main.go
@@ -47,9 +47,8 @@ var updateURL = ""          // ditto
 var publicKeyString = ""    // ditto
 var websiteURL = ""         // ditto
 
-
 func main() {
-	if (nameSuffix != "") {
+	if nameSuffix != "" {
 		appName += strings.Replace(nameSuffix, "_", " ", -1)
 	}
 

--- a/main.go
+++ b/main.go
@@ -1,3 +1,6 @@
+// This file is part of the program "NoiseTorch-ng".
+// Please see the LICENSE file for copyright information.
+
 package main
 
 import (

--- a/main.go
+++ b/main.go
@@ -45,6 +45,7 @@ var version = "unknown"     // ditto
 var distribution = "custom" // ditto
 var updateURL = ""          // ditto
 var publicKeyString = ""    // ditto
+var websiteURL = ""         // ditto
 
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -122,7 +122,7 @@ func getSources(client *pulseaudio.Client) []device {
 
 	outputs := make([]device, 0)
 	for i := range sources {
-		if strings.Contains(sources[i].Name, "nui_") || strings.Contains(sources[i].Name, "NoiseTorch") {
+		if strings.Contains(sources[i].Name, "nui_") || strings.Contains(sources[i].Name, "Filtered") {
 			continue
 		}
 
@@ -150,7 +150,7 @@ func getSinks(client *pulseaudio.Client) []device {
 
 	inputs := make([]device, 0)
 	for i := range sources {
-		if strings.Contains(sources[i].Name, "nui_") || strings.Contains(sources[i].Name, "NoiseTorch") {
+		if strings.Contains(sources[i].Name, "nui_") || strings.Contains(sources[i].Name, "Filtered") {
 			continue
 		}
 

--- a/module.go
+++ b/module.go
@@ -40,7 +40,7 @@ func supressorState(ctx *ntcontext) (int, bool) {
 	var virtualDeviceInUse bool = false
 	if ctx.config.FilterInput {
 		if ctx.serverInfo.servertype == servertype_pipewire {
-			module, ladspasource, err := findModule(c, "module-ladspa-source", "source_name='NoiseTorch Microphone")
+			module, ladspasource, err := findModule(c, "module-ladspa-source", "source_name='Filtered Microphone")
 			if err != nil {
 				log.Printf("Couldn't fetch module list to check for module-ladspa-source: %v\n", err)
 			}
@@ -79,7 +79,7 @@ func supressorState(ctx *ntcontext) (int, bool) {
 
 	if ctx.config.FilterOutput {
 		if ctx.serverInfo.servertype == servertype_pipewire {
-			module, ladspasink, err := findModule(c, "module-ladspa-sink", "sink_name='NoiseTorch Headphones'")
+			module, ladspasink, err := findModule(c, "module-ladspa-sink", "sink_name='Filtered Headphones'")
 			if err != nil {
 				log.Printf("Couldn't fetch module list to check for module-ladspa-sink: %v\n", err)
 			}
@@ -195,9 +195,9 @@ func loadModule(ctx *ntcontext, module, args string) (uint32, error) {
 func loadPipeWireInput(ctx *ntcontext, inp *device) error {
 	log.Printf("Loading supressor for pipewire\n")
 	idx, err := loadModule(ctx, "module-ladspa-source",
-		fmt.Sprintf("source_name='NoiseTorch Microphone for %s' master=%s "+
+		fmt.Sprintf("source_name='Filtered Microphone for %s' master=%s "+
 			"rate=48000 channels=1 "+
-			"label=noisetorch plugin=%s control=%d", inp.Name, inp.ID, ctx.librnnoise, ctx.config.Threshold))
+			"label=changemelater plugin=%s control=%d", inp.Name, inp.ID, ctx.librnnoise, ctx.config.Threshold))
 
 	if err != nil {
 		return err
@@ -209,9 +209,9 @@ func loadPipeWireInput(ctx *ntcontext, inp *device) error {
 func loadPipeWireOutput(ctx *ntcontext, out *device) error {
 	log.Printf("Loading supressor for pipewire\n")
 	idx, err := loadModule(ctx, "module-ladspa-sink",
-		fmt.Sprintf("sink_name='NoiseTorch Headphones' master=%s "+
+		fmt.Sprintf("sink_name='Filtered Headphones' master=%s "+
 			"rate=48000 channels=1 "+
-			"label=noisetorch plugin=%s control=%d", out.ID, ctx.librnnoise, ctx.config.Threshold))
+			"label=changemelater plugin=%s control=%d", out.ID, ctx.librnnoise, ctx.config.Threshold))
 
 	if err != nil {
 		return err
@@ -230,7 +230,7 @@ func loadPulseInput(ctx *ntcontext, inp *device) error {
 
 	idx, err = loadModule(ctx, "module-ladspa-sink",
 		fmt.Sprintf("sink_name=nui_mic_raw_in sink_master=nui_mic_denoised_out "+
-			"label=noisetorch plugin=%s control=%d", ctx.librnnoise, ctx.config.Threshold))
+			"label=changemelater plugin=%s control=%d", ctx.librnnoise, ctx.config.Threshold))
 	if err != nil {
 		return err
 	}
@@ -253,7 +253,7 @@ func loadPulseInput(ctx *ntcontext, inp *device) error {
 	}
 
 	idx, err = loadModule(ctx, "module-remap-source", fmt.Sprintf(`master=nui_mic_denoised_out.monitor `+
-		`source_name=nui_mic_remap source_properties="device.description='NoiseTorch Microphone for %s'"`, inp.Name))
+		`source_name=nui_mic_remap source_properties="device.description='Filtered Microphone for %s'"`, inp.Name))
 	if err != nil {
 		return err
 	}
@@ -267,13 +267,13 @@ func loadPulseOutput(ctx *ntcontext, out *device) error {
 		return err
 	}
 
-	_, err = loadModule(ctx, "module-null-sink", `sink_name=nui_out_in_sink sink_properties="device.description='NoiseTorch Headphones'"`)
+	_, err = loadModule(ctx, "module-null-sink", `sink_name=nui_out_in_sink sink_properties="device.description='Filtered Headphones'"`)
 	if err != nil {
 		return err
 	}
 
 	_, err = loadModule(ctx, "module-ladspa-sink", fmt.Sprintf(`sink_name=nui_out_ladspa sink_master=nui_out_out_sink `+
-		`label=noisetorch channels=1 plugin=%s control=%d rate=%d`,
+		`label=changemelater channels=1 plugin=%s control=%d rate=%d`,
 		ctx.librnnoise, ctx.config.Threshold, 48000))
 	if err != nil {
 		return err
@@ -306,7 +306,7 @@ func unloadSupressorPipeWire(ctx *ntcontext) error {
 
 	log.Printf("Searching for module-ladspa-source\n")
 	c := ctx.paClient
-	m, found, err := findModule(c, "module-ladspa-source", "source_name='NoiseTorch Microphone")
+	m, found, err := findModule(c, "module-ladspa-source", "source_name='Filtered Microphone")
 	if err != nil {
 		return err
 	}
@@ -316,7 +316,7 @@ func unloadSupressorPipeWire(ctx *ntcontext) error {
 	}
 
 	log.Printf("Searching for module-ladspa-sink\n")
-	m, found, err = findModule(c, "module-ladspa-sink", "sink_name='NoiseTorch Headphones'")
+	m, found, err = findModule(c, "module-ladspa-sink", "sink_name='Filtered Headphones'")
 	if err != nil {
 		return err
 	}

--- a/module.go
+++ b/module.go
@@ -1,3 +1,6 @@
+// This file is part of the program "NoiseTorch-ng".
+// Please see the LICENSE file for copyright information.
+
 package main
 
 import (

--- a/module.go
+++ b/module.go
@@ -197,7 +197,7 @@ func loadPipeWireInput(ctx *ntcontext, inp *device) error {
 	idx, err := loadModule(ctx, "module-ladspa-source",
 		fmt.Sprintf("source_name='Filtered Microphone for %s' master=%s "+
 			"rate=48000 channels=1 "+
-			"label=changemelater plugin=%s control=%d", inp.Name, inp.ID, ctx.librnnoise, ctx.config.Threshold))
+			"label=nt-filter plugin=%s control=%d", inp.Name, inp.ID, ctx.librnnoise, ctx.config.Threshold))
 
 	if err != nil {
 		return err
@@ -211,7 +211,7 @@ func loadPipeWireOutput(ctx *ntcontext, out *device) error {
 	idx, err := loadModule(ctx, "module-ladspa-sink",
 		fmt.Sprintf("sink_name='Filtered Headphones' master=%s "+
 			"rate=48000 channels=1 "+
-			"label=changemelater plugin=%s control=%d", out.ID, ctx.librnnoise, ctx.config.Threshold))
+			"label=nt-filter plugin=%s control=%d", out.ID, ctx.librnnoise, ctx.config.Threshold))
 
 	if err != nil {
 		return err
@@ -230,7 +230,7 @@ func loadPulseInput(ctx *ntcontext, inp *device) error {
 
 	idx, err = loadModule(ctx, "module-ladspa-sink",
 		fmt.Sprintf("sink_name=nui_mic_raw_in sink_master=nui_mic_denoised_out "+
-			"label=changemelater plugin=%s control=%d", ctx.librnnoise, ctx.config.Threshold))
+			"label=nt-filter plugin=%s control=%d", ctx.librnnoise, ctx.config.Threshold))
 	if err != nil {
 		return err
 	}
@@ -273,7 +273,7 @@ func loadPulseOutput(ctx *ntcontext, out *device) error {
 	}
 
 	_, err = loadModule(ctx, "module-ladspa-sink", fmt.Sprintf(`sink_name=nui_out_ladspa sink_master=nui_out_out_sink `+
-		`label=changemelater channels=1 plugin=%s control=%d rate=%d`,
+		`label=nt-filter channels=1 plugin=%s control=%d rate=%d`,
 		ctx.librnnoise, ctx.config.Threshold, 48000))
 	if err != nil {
 		return err

--- a/rlimit.go
+++ b/rlimit.go
@@ -1,3 +1,6 @@
+// This file is part of the program "NoiseTorch-ng".
+// Please see the LICENSE file for copyright information.
+
 package main
 
 import (

--- a/ui.go
+++ b/ui.go
@@ -83,17 +83,17 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 
 	if ctx.noiseSupressorState == loaded {
 		if ctx.virtualDeviceInUse {
-			w.LabelColored("NoiseTorch active", "RC", green)
+			w.LabelColored("Filtering active", "RC", green)
 		} else {
-			w.LabelColored("NoiseTorch unconfigured", "RC", lightBlue)
+			w.LabelColored("Filtering unconfigured", "RC", lightBlue)
 		}
 	} else if ctx.noiseSupressorState == unloaded {
 		_, inpOk := inputSelection(ctx)
 		_, outOk := outputSelection(ctx)
 		if validConfiguration(ctx, inpOk, outOk) {
-			w.LabelColored("NoiseTorch inactive", "RC", red)
+			w.LabelColored("Filtering inactive", "RC", red)
 		} else {
-			w.LabelColored("NoiseTorch unconfigured", "RC", lightBlue)
+			w.LabelColored("Filtering unconfigured", "RC", lightBlue)
 		}
 	} else if ctx.noiseSupressorState == inconsistent {
 		w.LabelColored("Inconsistent state, please unload first.", "RC", orange)
@@ -141,7 +141,7 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 
 		if ctx.reloadRequired {
 			w.Row(20).Dynamic(1)
-			w.LabelColored("Reloading NoiseTorch is required to apply these changes.", "LC", orange)
+			w.LabelColored("Reloading the filter(s) is required to apply these changes.", "LC", orange)
 		}
 
 		w.Row(15).Dynamic(2)
@@ -218,7 +218,7 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 
 	w.Row(25).Dynamic(2)
 	if ctx.noiseSupressorState != unloaded {
-		if w.ButtonText("Unload NoiseTorch") {
+		if w.ButtonText("Unload Filter(s)") {
 			ctx.reloadRequired = false
 			if ctx.virtualDeviceInUse {
 				confirm := makeConfirmView(ctx,
@@ -226,19 +226,19 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 					"Some applications may behave weirdly when you remove a device they're currently using",
 					"Unload",
 					"Go back",
-					func() { uiUnloadNoisetorch(ctx) },
+					func() { uiUnloadFilters(ctx) },
 					func() {})
 				ctx.views.Push(confirm)
 			} else {
-				go uiUnloadNoisetorch(ctx)
+				go uiUnloadFilters(ctx)
 			}
 		}
 	} else {
 		w.Spacing(1)
 	}
-	txt := "Load NoiseTorch"
+	txt := "Load Filter(s)"
 	if ctx.noiseSupressorState == loaded {
-		txt = "Reload NoiseTorch"
+		txt = "Reload Filter(s)"
 	}
 
 	inp, inpOk := inputSelection(ctx)
@@ -253,11 +253,11 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 					"Some applications may behave weirdly when you reload a device they're currently using",
 					"Reload",
 					"Go back",
-					func() { uiReloadNoisetorch(ctx, inp, out) },
+					func() { uiReloadFilters(ctx, inp, out) },
 					func() {})
 				ctx.views.Push(confirm)
 			} else {
-				go uiReloadNoisetorch(ctx, inp, out)
+				go uiReloadFilters(ctx, inp, out)
 			}
 		}
 	} else {
@@ -266,7 +266,7 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 
 }
 
-func uiUnloadNoisetorch(ctx *ntcontext) {
+func uiUnloadFilters(ctx *ntcontext) {
 	ctx.views.Push(loadingView)
 	if err := unloadSupressor(ctx); err != nil {
 		log.Println(err)
@@ -281,7 +281,7 @@ func uiUnloadNoisetorch(ctx *ntcontext) {
 	(*ctx.masterWindow).Changed()
 }
 
-func uiReloadNoisetorch(ctx *ntcontext, inp, out device) {
+func uiReloadFilters(ctx *ntcontext, inp, out device) {
 	ctx.views.Push(loadingView)
 	if ctx.noiseSupressorState == loaded {
 		if err := unloadSupressor(ctx); err != nil {
@@ -393,7 +393,7 @@ func connectView(ctx *ntcontext, w *nucular.Window) {
 
 func capabilitiesView(ctx *ntcontext, w *nucular.Window) {
 	w.Row(15).Dynamic(1)
-	w.Label("NoiseTorch currently does not have the capabilities to function properly.", "CB")
+	w.Label("This program does not have the capabilities to function properly.", "CB")
 	w.Row(15).Dynamic(1)
 	w.Label("We require CAP_SYS_RESOURCE. If that doesn't mean anything to you, don't worry. I'll fix it for you.", "CB")
 	if ctx.capsMismatch {

--- a/ui.go
+++ b/ui.go
@@ -53,6 +53,8 @@ var red = color.RGBA{255, 70, 70, 255}
 var orange = color.RGBA{255, 140, 0, 255}
 var lightBlue = color.RGBA{173, 216, 230, 255}
 
+const notice = "NoiseTorch Next Gen (stylized NoiseTorch-ng) is a continuation of the NoiseTorch\nproject after it was abandonned by its original author. Please do not confuse\nboth programs. You may convey modified versions of this program under its name."
+
 func updatefn(ctx *ntcontext, w *nucular.Window) {
 	currView := ctx.views.Peek()
 	currView(ctx, w)
@@ -357,7 +359,10 @@ func loadingView(ctx *ntcontext, w *nucular.Window) {
 }
 
 func licenseView(ctx *ntcontext, w *nucular.Window) {
-	w.Row(255).Dynamic(1)
+	w.Row(40).Dynamic(1) // space above notice
+	w.Label(notice, "CB")
+	w.Row(40).Dynamic(1)  // space below notice
+	w.Row(255).Dynamic(1) // space for license text area
 	field := &ctx.licenseTextArea
 	field.Flags |= nucular.EditMultiline
 	if len(field.Buffer) < 1 {
@@ -375,6 +380,8 @@ func licenseView(ctx *ntcontext, w *nucular.Window) {
 func versionView(ctx *ntcontext, w *nucular.Window) {
 	w.Row(50).Dynamic(1)
 	w.Label("Version", "CB")
+	w.Row(50).Dynamic(1)
+	w.Label(notice, "CB")
 	w.Row(50).Dynamic(1)
 	w.Label(fmt.Sprintf("%s (%s)", version, distribution), "CB")
 	w.Row(50).Dynamic(1)

--- a/ui.go
+++ b/ui.go
@@ -69,8 +69,8 @@ func mainView(ctx *ntcontext, w *nucular.Window) {
 			ctx.views.Push(licenseView)
 		}
 		w.Row(10).Dynamic(1)
-		if w.MenuItem(label.T("Source code")) {
-			exec.Command("xdg-open", "https://github.com/noisetorch/NoiseTorch").Run()
+		if w.MenuItem(label.T("Website")) {
+			exec.Command("xdg-open", websiteURL).Run()
 		}
 		if w.MenuItem(label.T("Version")) {
 			ctx.views.Push(versionView)

--- a/ui.go
+++ b/ui.go
@@ -1,3 +1,6 @@
+// This file is part of the program "NoiseTorch-ng".
+// Please see the LICENSE file for copyright information.
+
 package main
 
 import (
@@ -53,7 +56,7 @@ var red = color.RGBA{255, 70, 70, 255}
 var orange = color.RGBA{255, 140, 0, 255}
 var lightBlue = color.RGBA{173, 216, 230, 255}
 
-const notice = "NoiseTorch Next Gen (stylized NoiseTorch-ng) is a continuation of the NoiseTorch\nproject after it was abandonned by its original author. Please do not confuse\nboth programs. You may convey modified versions of this program under its name."
+const notice = "NoiseTorch Next Gen (stylized NoiseTorch-ng) is a continuation of the NoiseTorch\nproject after it was abandoned by its original author. Please do not confuse\nboth programs. You may convey modified versions of this program under its name."
 
 func updatefn(ctx *ntcontext, w *nucular.Window) {
 	currView := ctx.views.Peek()

--- a/update.go
+++ b/update.go
@@ -130,7 +130,7 @@ func update(ctx *ntcontext) {
 	pkexecSetcapSelf()
 
 	log.Printf("Update installed!\n")
-	ctx.update.updatingText = "Update installed! (Restart NoiseTorch to apply)"
+	ctx.update.updatingText = "Update installed! (Restart the program to apply)"
 	(*ctx.masterWindow).Changed()
 }
 

--- a/update.go
+++ b/update.go
@@ -1,3 +1,6 @@
+// This file is part of the program "NoiseTorch-ng".
+// Please see the LICENSE file for copyright information.
+
 package main
 
 import (

--- a/views.go
+++ b/views.go
@@ -1,3 +1,6 @@
+// This file is part of the program "NoiseTorch-ng".
+// Please see the LICENSE file for copyright information.
+
 package main
 
 import (


### PR DESCRIPTION
* Remove references to NoiseTorch throughout the UI
* Add a way to add a suffix to the end of the program name to indicate things such as a third-party or dev build
* Add a way to set a custom website url (i.e. AUR url)

This is really a two-parted thing: many references to NoiseTorch have been removed, which will make changing the name easier, as well as make it easier for third-party packagers to deal with the license. Adding the ability to set a suffix, as well as a custom url, will hopefully also help in the marking of third-party builds.

I'm making this as a draft, as this needs to be tested with pulseaudio as the backend to ensure I didn't break anything on the pulseaudio front. Things seems to be working as expected on the pipewire side of things.

I'd appreciate it if someone who uses pulseaudio would be able to test this. 