### PR TITLE
Do not check latest release if updates disabled

### DIFF
--- a/update.go
+++ b/update.go
@@ -78,9 +78,16 @@ type updateui struct {
 	updatingText  string
 }
 
-var latestRelease, releaseError = getLatestRelease()
-var latestVersion, _ = semver.Make(strings.TrimLeft(latestRelease, "v"))
-var currentVersion, _ = semver.Make(strings.TrimLeft(version, "v"))
+var latestRelease string
+var releaseError error
+
+func init() {
+	if !updateable() {
+		return
+	}
+
+	latestRelease, releaseError = getLatestRelease()
+}
 
 func updateable() bool {
 	return updateURL != "" && publicKeyString != "" && releaseError == nil
@@ -91,6 +98,9 @@ func updateCheck(ctx *ntcontext) {
 		return
 	}
 	log.Println("Checking for updates")
+
+	var latestVersion, _ = semver.Make(strings.TrimLeft(latestRelease, "v"))
+	var currentVersion, _ = semver.Make(strings.TrimLeft(version, "v"))
 
 	ctx.update.serverVersion = latestRelease
 	if currentVersion.Compare(latestVersion) == -1 {


### PR DESCRIPTION
Fixes #345

## Why

#345 stemmed from a Nixpkgs issue, where the author saw a timeout message while checking for updates: https://github.com/NixOS/nixpkgs/pull/179088#issuecomment-1167959829

This is actually due to this module-level function call, which calls out to github to check the latest current release.

https://github.com/noisetorch/NoiseTorch/blob/ebf595ba4bf4c8143b1c60b0a787e144dede5824/update.go#L81

## What

This moves the function call to an `init()` function, so we can avoid this check entirely if updates have been disabled through build variable.

## Testing

 - I can build and run the program with `UPDATE_URL` both as normal and empty in the `Makefile`
 - I ran `gofmt`