### PR TITLE
Fix naming of audio devices under PipeWire

### DIFF
--- a/cli.go
+++ b/cli.go
@@ -88,13 +88,13 @@ func doCLI(opt CLIOpts, config *config, librnnoise string) {
 
 	if opt.list {
 		fmt.Println("Sources:")
-		sources := getSources(paClient)
+		sources := getSources(&ctx, paClient)
 		for i := range sources {
 			fmt.Printf("\tDevice Name: %s\n\tDevice ID: %s\n\n", sources[i].Name, sources[i].ID)
 		}
 
 		fmt.Println("Sinks:")
-		sinks := getSinks(paClient)
+		sinks := getSinks(&ctx, paClient)
 		for i := range sinks {
 			fmt.Printf("\tDevice Name: %s\n\tDevice ID: %s\n\n", sinks[i].Name, sinks[i].ID)
 		}
@@ -121,7 +121,7 @@ func doCLI(opt CLIOpts, config *config, librnnoise string) {
 	}
 
 	if opt.loadInput {
-		sources := getSources(paClient)
+		sources := getSources(&ctx, paClient)
 
 		if opt.sinkName == "" {
 			defaultSource, err := getDefaultSourceID(paClient)
@@ -147,7 +147,7 @@ func doCLI(opt CLIOpts, config *config, librnnoise string) {
 
 	}
 	if opt.loadOutput {
-		sinks := getSinks(paClient)
+		sinks := getSinks(&ctx, paClient)
 
 		if opt.sinkName == "" {
 			defaultSink, err := getDefaultSinkID(paClient)


### PR DESCRIPTION
Under PulseAudio, the user-friendly name for each audio device was
stored under its `device.description` property. Under PipeWire,
`device.description` is the name of the sound card, not the source/sink.
This results in all source devices showing their sound card's name in
NoiseTorch. Since I have multiple sources on the same sound card, it
meant all my microphones had the same name, making NoiseTorch unusable.

This commit changes the assignment of device names. When running under
PipeWire, the `pulseaudio.Source.Description` field holds the correct
device name, while the
`pulseaudio.Source.PropList["device.description"]` field that was being
used previously is the sound card's description.

The NoiseTorch context must now be passed to the `getSources` and
`getSinks` functions so they can check whether the program is running
under PulseAudio or PipeWire.

### Screenshot
Before is on the left, after is on the right.
![before/after screenshot](https://user-images.githubusercontent.com/63574107/185770632-e5be6656-e4df-4a59-b3f0-68a43002dc29.png)
Ignore the first device on the left, as it is produced by the "fixed" NoiseTorch instance and would otherwise not be there.
