### PR TITLE
docs: create ~/.local/bin dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Install the Go compiler from [golang.org](https://golang.org/). And make sure yo
 To install it:
 
 ```shell
+mkdir -p  ~/.local/bin
 cp ./bin/noisetorch ~/.local/bin
 cp ./assets/noisetorch.desktop ~/.local/share/applications
 cp ./assets/icon/noisetorch.png ~/.local/share/icons/hicolor/256x256/apps

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ To install it:
 
 ```shell
 mkdir -p  ~/.local/bin
-cp ./bin/noisetorch ~/.local/bin
+cp ./bin/noisetorch ~/.local/bin/
 cp ./assets/noisetorch.desktop ~/.local/share/applications
 cp ./assets/icon/noisetorch.png ~/.local/share/icons/hicolor/256x256/apps
 ```


### PR DESCRIPTION
If the `~/.local/bin` directory doesn't exists (was the case for me on POP OS) the cp command will copy the noisetorch binary to `~/.local/bin` and not into the folder (`~/.local/bin/noisetorch`)