### PR TITLE
Add a generic name to noisetorch.desktop

### DIFF
--- a/assets/noisetorch.desktop
+++ b/assets/noisetorch.desktop
@@ -1,5 +1,6 @@
 [Desktop Entry]
 Name=NoiseTorch
+GenericName=Realtime Noise Suppressor
 Comment=Create a virtual microphone that suppresses noise, in any application.
 Exec=noisetorch
 Icon=noisetorch


### PR DESCRIPTION
Some application launchers will fallback to the comment if a generic name isn't provided, so this change adds a generic name. This makes it more consistent with other applications a user may have.

Before:
![image](https://github.com/noisetorch/NoiseTorch/assets/101067949/940c1388-ba3b-4e5b-836c-32b4761bb3bf)

After:
![image](https://github.com/noisetorch/NoiseTorch/assets/101067949/39d0e501-183e-4250-a87c-5a1186aed743)
