### PR TITLE
feat: Make install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,11 @@ dev: rnnoise
 	mkdir -p bin/
 	go generate
 	go build -ldflags '-X main.nameSuffix=${NAME_SUFFIX}_(dev) -X main.version=${VERSION} -X main.websiteURL=${WEBSITE_URL}' -o bin/noisetorch
-release: rnnoise
+release_build: rnnoise
 	mkdir -p bin/
+	go generate
+	CGO_ENABLED=0 GOOS=linux go build -trimpath -tags release -a -ldflags '-s -w -extldflags "-static" -X main.nameSuffix=${NAME_SUFFIX} -X main.version=${VERSION} -X main.distribution=official -X main.updateURL=${UPDATE_URL} -X main.publicKeyString=${UPDATE_PUBKEY} -X main.websiteURL=${WEBSITE_URL}' .
+release: rnnoise release_build
 	mkdir -p tmp/
 
 	mkdir -p tmp/.local/share/icons/hicolor/256x256/apps/
@@ -20,9 +23,7 @@ release: rnnoise
 	cp assets/noisetorch.desktop tmp/.local/share/applications/
 
 	mkdir -p tmp/.local/bin/
-	go generate
-	CGO_ENABLED=0 GOOS=linux go build -trimpath -tags release -a -ldflags '-s -w -extldflags "-static" -X main.nameSuffix=${NAME_SUFFIX} -X main.version=${VERSION} -X main.distribution=official -X main.updateURL=${UPDATE_URL} -X main.publicKeyString=${UPDATE_PUBKEY} -X main.websiteURL=${WEBSITE_URL}' .
-	mv noisetorch tmp/.local/bin/
+	cp noisetorch tmp/.local/bin/
 	cd tmp/; \
 	tar cvzf ../bin/NoiseTorch_x64_${VERSION}.tgz .
 	rm -rf tmp/
@@ -30,3 +31,15 @@ release: rnnoise
 rnnoise:
 	git submodule update --init --recursive
 	$(MAKE) -C c/ladspa
+install: rnnoise release_build
+	mkdir -p ~/.local/share/icons/hicolor/256x256/apps/
+	mkdir -p ~/.local/share/applications/
+	mkdir -p ~/.local/bin/
+	cp noisetorch ~/.local/bin/
+	cp assets/noisetorch.desktop ~/.local/share/applications/
+	cp assets/icon/noisetorch.png ~/.local/share/icons/hicolor/256x256/apps/
+uninstall:
+	rm ~/.local/share/icons/hicolor/256x256/apps/noisetorch.png || true
+	rm ~/.local/share/applications/noisetorch.desktop || true
+	rm ~/.local/bin/noisetorch || true
+

--- a/README.md
+++ b/README.md
@@ -125,18 +125,15 @@ Output filtering currently introduces something on the order of ~100ms with puls
 Install the Go compiler from [golang.org](https://golang.org/). And make sure you have a working C++ compiler.
 
 ```shell
- git clone https://github.com/noisetorch/NoiseTorch # Clone the repository
- cd NoiseTorch # cd into the cloned repository
- make # build it
+git clone https://github.com/noisetorch/NoiseTorch # Clone the repository
+cd NoiseTorch # cd into the cloned repository
+make # build it
 ```
 
 To install it:
 
 ```shell
-mkdir -p  ~/.local/bin
-cp ./bin/noisetorch ~/.local/bin/
-cp ./assets/noisetorch.desktop ~/.local/share/applications
-cp ./assets/icon/noisetorch.png ~/.local/share/icons/hicolor/256x256/apps
+make install
 ```
 
 ## Special thanks to


### PR DESCRIPTION
This PR adds a `make install` and `make uninstall` targets.

It uses the build commands from the release target, but extracts it into a separate target to DRY it.