### PR TITLE
Fix PipeWire 1.6+ LADSPA plugin loading (no longer accepts /tmp paths)

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -20,7 +20,7 @@ jobs:
           go-version: 1.18
       - uses: actions/checkout@v4
       - run: make dev
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: linux_x64
           path: ${{ github.workspace }}/bin/noisetorch

--- a/module.go
+++ b/module.go
@@ -197,10 +197,13 @@ func loadModule(ctx *ntcontext, module, args string) (uint32, error) {
 
 func loadPipeWireInput(ctx *ntcontext, inp *device) error {
 	log.Printf("Loading supressor for pipewire\n")
+	// PipeWire 1.6+ filter-graph LADSPA backend searches LADSPA dirs
+	// (e.g. /usr/lib/ladspa) and does not accept arbitrary /tmp paths.
+	// Pass the plugin name only; the .so must be installed to a LADSPA dir.
 	idx, err := loadModule(ctx, "module-ladspa-source",
 		fmt.Sprintf("source_name='Filtered Microphone for %s' master=%s "+
 			"rate=48000 channels=1 "+
-			"label=nt-filter plugin=%s control=%d", inp.Name, inp.ID, ctx.librnnoise, ctx.config.Threshold))
+			"label=nt-filter plugin=rnnoise_ladspa control=%d", inp.Name, inp.ID, ctx.config.Threshold))
 
 	if err != nil {
 		return err
@@ -211,10 +214,13 @@ func loadPipeWireInput(ctx *ntcontext, inp *device) error {
 
 func loadPipeWireOutput(ctx *ntcontext, out *device) error {
 	log.Printf("Loading supressor for pipewire\n")
+	// PipeWire 1.6+ filter-graph LADSPA backend searches LADSPA dirs
+	// (e.g. /usr/lib/ladspa) and does not accept arbitrary /tmp paths.
+	// Pass the plugin name only; the .so must be installed to a LADSPA dir.
 	idx, err := loadModule(ctx, "module-ladspa-sink",
 		fmt.Sprintf("sink_name='Filtered Headphones' master=%s "+
 			"rate=48000 channels=1 "+
-			"label=nt-filter plugin=%s control=%d", out.ID, ctx.librnnoise, ctx.config.Threshold))
+			"label=nt-filter plugin=rnnoise_ladspa control=%d", out.ID, ctx.config.Threshold))
 
 	if err != nil {
 		return err


### PR DESCRIPTION
PipeWire 1.6+ filter-graph LADSPA backend no longer accepts arbitrary paths (e.g. /tmp/librnnoise-XXXX.so) as the plugin= argument. It only searches configured LADSPA directories (/usr/lib64/ladspa, /usr/lib/ladspa, /usr/lib, and $LADSPA_PATH).

 The PipeWire journal shows the actual error:
```
failed to load plugin '/tmp/librnnoise-XXXX.so' in '/usr/lib64/ladspa:/usr/lib/ladspa:/usr/lib': No such file or directory
```

Fix: pass 'plugin=rnnoise_ladspa' by name in loadPipeWireInput and loadPipeWireOutput instead of the full temp file path. The rnnoise_ladspa.so must be installed to a LADSPA directory (e.g. /usr/lib/ladspa/).

The PulseAudio code paths are unchanged — they still use the full path, which works on real PulseAudio.

### Testing
Tested on PipeWire 1.6.4 (CachyOS). noisetorch -i <device> previously exited with code 1; now loads successfully.

### Changelist 
module.go: +6/-2

### Unmitigated
the NoiseTorch install process (Makefile release target or a future install script) should copy rnnoise_ladspa.so to /usr/lib/ladspa/ — the current release tarball doesn't do this. That's a follow-on issue.