### PR TITLE
Update rnnoise to follow upstream (latest stable)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "c/rnnoise"]
 	path = c/rnnoise
-	url = https://github.com/noisetorch/rnnoise
+	url = https://gitlab.xiph.org/xiph/rnnoise.git
 [submodule "c/c-ringbuf"]
 	path = c/c-ringbuf
 	url = https://github.com/noisetorch/c-ringbuf


### PR DESCRIPTION
Tested with Carla/Ladspa, Go code still untested.

This is a "just works", it's here for anyone who wants to try.

P.S. upstream renamed master to main and there's also some performance patches, but they were never tested properly (i.e. compilation errors) so I'll have to look in to getting fixes merged upstream.